### PR TITLE
Add the referral code to the new user registration form.

### DIFF
--- a/convention/views/user.py
+++ b/convention/views/user.py
@@ -8,7 +8,7 @@ from django.views.generic import TemplateView
 from registration.backends.hmac.views import RegistrationView as BaseRegistrationView
 
 from ..forms import NewUserForm, AttendanceForm
-from ..models import Registration, PaymentOption, BlockRegistration, TimeBlock, get_choice
+from ..models import Registration, PaymentOption, BlockRegistration, TimeBlock, get_choice, Referral
 from ..utils import friendly_username, is_registration_open, is_pre_reg_open
 from .common import RegistrationOpenMixin, NotOnWaitingListMixin, IsStaffMixin
 
@@ -120,6 +120,17 @@ class AttendanceList(LoginRequiredMixin, IsStaffMixin, TemplateView):
 
 class NewUserView(BaseRegistrationView):
     form_class = NewUserForm
+
+    def form_valid(self, form):
+        redirect = super(NewUserView, self).form_valid(form)
+
+        code = form.cleaned_data.get('referral_code')
+        if code != "":
+            referral = Referral.objects.filter(code=code)[0]
+            referral.referred_user = form.instance
+            referral.save()
+
+        return redirect
 
 
 class NotAlreadyPaid(AccessMixin):


### PR DESCRIPTION
Not entirely a fan of the cross-module dependency in the unit tests for this, but it's down to the wire. We'll have plenty of time to worry about cleaning that sort of thing up later.